### PR TITLE
Fix for issue #3 - Document links don't work in pdf

### DIFF
--- a/mkdocs_with_pdf/generator.py
+++ b/mkdocs_with_pdf/generator.py
@@ -62,6 +62,7 @@ class Generator(object):
             if self._options.heading_shift:
                 article = self._shift_heading(article, page, page.parent)
 
+            article['id'] = f'{page.url}'
             article['data-url'] = f'/{page.url}'
             setattr(page, 'pdf-article', article)
 

--- a/mkdocs_with_pdf/generator.py
+++ b/mkdocs_with_pdf/generator.py
@@ -136,11 +136,7 @@ class Generator(object):
 
         if page == parent.children[0]:
             article = self._shift_heading(article, parent, parent.parent)
-
-            id = page.url if (hasattr(page, 'url') and page.url) else ''
-            id = id.strip('/').rstrip('/')
-            id = id if id else str(uuid4())
-
+            
             soup = BeautifulSoup('', 'html.parser')
             h1 = soup.new_tag('h1', id=f'{id}')
             h1.append(parent.title)

--- a/mkdocs_with_pdf/preprocessor/links/transform.py
+++ b/mkdocs_with_pdf/preprocessor/links/transform.py
@@ -73,7 +73,7 @@ def _transform_href(href: str, rel_url: str) -> str:
             return href
 
         href = _normalize_href(href, rel_url)
-        return '#{}:'.format(href)
+        return '#{}'.format(href)
 
     if head != '' and not head.endswith('/'):
         head += '/'

--- a/mkdocs_with_pdf/preprocessor/links/transform.py
+++ b/mkdocs_with_pdf/preprocessor/links/transform.py
@@ -64,11 +64,11 @@ def _transform_href(href: str, rel_url: str) -> str:
             if href.endswith('.png'):
                 return href
             id = '' if not href.endswith('/') else href.split('/')[-2]
-            return f'#{href}:{id}'
+            return f'#{href}:{id}' if (id) else f'#{href}'
         elif href.startswith('..'):
             id = '' if not href.endswith('/') else href.split('/')[-2]
             href = _normalize_href(href, rel_url)
-            return f'#{href}:{id}'
+            return f'#{href}:{id}' if (id) else f'#{href}'
         elif not is_doc(href):
             return href
 
@@ -78,7 +78,7 @@ def _transform_href(href: str, rel_url: str) -> str:
     if head != '' and not head.endswith('/'):
         head += '/'
 
-    return '#{}{}:{}'.format(head, section, id)
+    return '#{}{}:{}'.format(head, section, id) if (id) else '#{}{}'.format(head, section)
 
 
 def _normalize_href(href: str, rel_url: str) -> str:


### PR DESCRIPTION
This pull request fixes internal document links.  The code in this pull request does:

1) Removes the id attribute being added to h1 tags for the first page in a navigation section.  The id contained the link generated for an internal page link : [desc](page.md)
2) Adds an id tag to the article tag containing a page for all pages referenced in the navigation config.  This provides the anchors for internal page links
3) Fixes the link transformations to remove training : when there is no id in the link