### PR TITLE
options: Allow user to set theme-path in localconf

### DIFF
--- a/mkdocs_with_pdf/options.py
+++ b/mkdocs_with_pdf/options.py
@@ -93,7 +93,9 @@ class Options(object):
 
         # Theming
         self.theme_name = config['theme'].name
-        self.theme_handler_path = config.get('theme_handler_path', None)
+        if not self.theme_handler_path:
+            # Read from global config only if plugin config is not set
+            self.theme_handler_path = config.get('theme_handler_path', None)
 
         # for system
         self._logger = logger


### PR DESCRIPTION
Earlier, the local config for theme_handler_path was being
ignored/overwritten by the global equivalent of this config.
Now, use local config if it is present - else, check for global config

Fixes: https://github.com/orzih/mkdocs-with-pdf/issues/26