### PR TITLE
Support for Mermaid Diagrams using ReLaXed JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,21 @@ plugins:
 >    <ANY_SITE_URL(eg. 'https://google.com')>
 > ```
 
+* `use_relaxed_js_renderer`
+
+    Set the value to `true` if you're using e.g. '[Mermaid](https://mermaid-js.github.io) diagrams and Headless Chrome is not working for you.
+    Require "ReLaXed" Javascript PDF renderer to be installed on your system. See: '[ReLaXed](https://github.com/RelaxedJS/ReLaXed)'.
+
+    Please use 'theme_handler_path' option to specify custom JS sources and CSS Stylesheets which covers your needs. E.g. for Material
+    theme it would be **material.py**. See: **mkdocs-with-pdf/mkdocs_with_pdf/themes/material.py** for implementation details.
+    **default**: `false`
+
+> Install on your system:
+> ```
+> $ npm i -g relaxedjs
+> $ relaxed --version
+> ```
+
 ##### ... and more
 
 * `output_path`

--- a/mkdocs_with_pdf/options.py
+++ b/mkdocs_with_pdf/options.py
@@ -21,7 +21,8 @@ class Options(object):
         ('debug_html', config_options.Type(bool, default=False)),
         ('show_anchors', config_options.Type(bool, default=False)),
 
-        ('output_path', config_options.Type(str, default="pdf/document.pdf")),
+        ('output_pdf_name', config_options.Type(str, default="document")),
+        ('output_path', config_options.Type(str, default="pdf/")),
         ('theme_handler_path', config_options.Type(str, default=None)),
 
         ('author', config_options.Type(str, default=None)),
@@ -43,7 +44,9 @@ class Options(object):
 
         ('render_js', config_options.Type(bool, default=False)),
         ('headless_chrome_path',
-            config_options.Type(str, default='chromium-browser'))
+            config_options.Type(str, default='chromium-browser')),
+        ('use_relaxed_js_renderer',
+            config_options.Type(bool, default=False)),
     )
 
     def __init__(self, local_config, config, logger: logging):
@@ -54,6 +57,7 @@ class Options(object):
         self.show_anchors = local_config['show_anchors']
 
         self.output_path = local_config.get('output_path', None)
+        self.output_pdf_name = local_config.get('output_pdf_name', None)
         self.theme_handler_path = local_config.get('theme_handler_path', None)
 
         # Author and Copyright
@@ -84,6 +88,11 @@ class Options(object):
         self.convert_iframe = local_config['convert_iframe']
 
         self.two_columns_level = local_config['two_columns_level']
+
+        if local_config['use_relaxed_js_renderer']:
+            self.use_relaxed_js_renderer = True
+        else:
+            self.use_relaxed_js_renderer = False
 
         # ...etc.
         self.js_renderer = None


### PR DESCRIPTION
Add option to use 'ReLaXeD' JS renderer for PDF
instead of Headless Chrome.

option added: use_relaxed_js_renderer

option changed:
 - output_pdf_name: default 'document' as before
 - output_path:     contains now only directory name
                    not a file name

Issue #34

This involves few changes that was handy for me, but it changes the
options naming, which may be not desired in the end, but I wanted
first to publish all the changes that works for me locally ;)