### PR TITLE
removed compressed css output_style to avoid problems with umlauts

### DIFF
--- a/mkdocs_with_pdf/styles/__init__.py
+++ b/mkdocs_with_pdf/styles/__init__.py
@@ -33,21 +33,17 @@ def style_for_print(options: Options) -> str:
     """
     css = sass.compile(string=scss)
 
-    output_style = 'compressed'
-    if options.debug_html:
-        output_style = 'nested'
-
     base_path = os.path.abspath(os.path.dirname(__file__))
 
     filename = os.path.join(base_path, "report-print.scss")
-    css += sass.compile(filename=filename, output_style=output_style)
+    css += sass.compile(filename=filename)
 
     if options.cover or options.back_cover:
         filename = os.path.join(base_path, "cover.scss")
-        css += sass.compile(filename=filename, output_style=output_style)
+        css += sass.compile(filename=filename)
 
     filename = os.path.join(options.custom_template_path, 'styles.scss')
     if os.path.exists(filename):
-        css += sass.compile(filename=filename, output_style=output_style)
+        css += sass.compile(filename=filename)
 
     return css

--- a/mkdocs_with_pdf/themes/material.py
+++ b/mkdocs_with_pdf/themes/material.py
@@ -9,10 +9,7 @@ def get_stylesheet(debug_html: bool) -> str:
     style = ""
     for src in ["material.scss", "material-polyfills.css"]:
         filename = os.path.join(base_path, src)
-        output_style = 'compressed'
-        if debug_html:
-            output_style = 'nested'
-        style += sass.compile(filename=filename, output_style=output_style)
+        style += sass.compile(filename=filename)
     return style
 
 

--- a/mkdocs_with_pdf/themes/mkdocs.py
+++ b/mkdocs_with_pdf/themes/mkdocs.py
@@ -7,10 +7,7 @@ from bs4 import BeautifulSoup
 def get_stylesheet(debug_html: bool) -> str:
     base_path = os.path.abspath(os.path.dirname(__file__))
     filename = os.path.join(base_path, "mkdocs.scss")
-    output_style = 'compressed'
-    if debug_html:
-        output_style = 'nested'
-    return sass.compile(filename=filename, output_style=output_style)
+    return sass.compile(filename=filename)
 
 
 def get_script_sources() -> list:


### PR DESCRIPTION
Compiling scss to compressed css using `sass.compile(filename=filename, output_style=output_style)` causes problems when using umlauts (e.g. in generated content).
Since I see no benefit in using compressed css, I removed the compression.