### PR TITLE
Compatible with mkdocs-static-i18n plugin

### DIFF
--- a/mkdocs_with_pdf/options.py
+++ b/mkdocs_with_pdf/options.py
@@ -52,7 +52,8 @@ class Options(object):
         self.debug_html = local_config['debug_html']
         self.show_anchors = local_config['show_anchors']
 
-        self.output_path = local_config.get('output_path', None)
+        self.output_path = config["plugins"]["with-pdf"].config.get(
+            "output_path", None)
 
         # Author and Copyright
         self._author = local_config['author']

--- a/mkdocs_with_pdf/options.py
+++ b/mkdocs_with_pdf/options.py
@@ -52,8 +52,7 @@ class Options(object):
         self.debug_html = local_config['debug_html']
         self.show_anchors = local_config['show_anchors']
 
-        self.output_path = config["plugins"]["with-pdf"].config.get(
-            "output_path", None)
+        self.output_path = config["plugins"]["with-pdf"].config["output_path"]
 
         # Author and Copyright
         self._author = local_config['author']

--- a/mkdocs_with_pdf/plugin.py
+++ b/mkdocs_with_pdf/plugin.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from timeit import default_timer as timer
+from copy import deepcopy
 
 from mkdocs.plugins import BasePlugin
 
@@ -45,7 +46,7 @@ class WithPdfPlugin(BasePlugin):
 
     config_scheme = Options.config_scheme
 
-    def __init__(self):
+    def __init__(self, config=None):
         self._logger = logging.getLogger('mkdocs.with-pdf')
         self._logger.setLevel(logging.INFO)
 
@@ -56,6 +57,12 @@ class WithPdfPlugin(BasePlugin):
         self._total_time = 0
 
         self._error_counter = None
+
+        if config:
+            self.config = config
+
+    def __deepcopy__(self, memo):
+        return WithPdfPlugin(deepcopy(self.config, memo))
 
     def on_serve(self, server, config, builder, **kwargs):
         EventHookHandler.on_serve(server, builder, self._logger)


### PR DESCRIPTION
Overall PR: https://github.com/mkdocs/mkdocs/pull/2487

To make this plugin compatible with the [mkdocs-static-i18n](https://github.com/ultrabug/mkdocs-static-i18n) plugin it have to be deep copyable. It should also get the config from the object passed to the on_config event and not the locale one, because the i18n plugin prefixes the output_path with the language on a deep copied config.