### PR TITLE
Fix: AttributeError. Don't need a cover page

### DIFF
--- a/mkdocs_with_pdf/options.py
+++ b/mkdocs_with_pdf/options.py
@@ -71,6 +71,11 @@ class Options(object):
                 if local_config['cover_title'] else config['site_name']
             self._cover_subtitle = local_config['cover_subtitle']
             self._cover_logo = local_config['cover_logo']
+        else:
+            self._cover_title = ""
+            self._cover_subtitle = ""
+            self._cover_logo = ""
+
 
         # path to custom template 'cover.html' and custom scss 'styles.scss'
         self.custom_template_path = local_config['custom_template_path']


### PR DESCRIPTION
Set cover-related variables to an empty string when cover and
back_cover options are set to false.

Signed-off-by: Javier Alvarez <j.alvarez@genexis.eu>