### PR TITLE
#86 : Fixing wrong path format for Windows

### DIFF
--- a/mkdocs_with_pdf/templates/filters/url.py
+++ b/mkdocs_with_pdf/templates/filters/url.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from urllib.parse import urlparse
 
 from . import _FilterBase
@@ -29,7 +30,9 @@ class URLFilter(_FilterBase):
                 continue
             path = os.path.abspath(os.path.join(d, pathname))
             if os.path.isfile(path):
-                return 'file://' + path
+                return 'file:///' + path.replace("\\", "/") \
+                        if sys.platform == 'win32' \
+                        else 'file://' + path
 
         # not found?
         return pathname


### PR DESCRIPTION
#86 : Fixing logo page not displaying on Windows.

Adapted path format if the build platform is Windows.

Thank you @jolekss