### PR TITLE
Fix: indentation of list with mkdocs-material as theme

### DIFF
--- a/mkdocs_with_pdf/themes/material.scss
+++ b/mkdocs_with_pdf/themes/material.scss
@@ -1,3 +1,11 @@
+.md-typeset > ul {
+  margin-left: 0rem !important;
+}
+.md-typeset ul li,
+.md-typeset ol li {
+  margin-left: 1.5rem !important;
+}
+
 @media print {
   .md-typeset {
     // Tabbed code block container
@@ -65,7 +73,8 @@
         padding-bottom: 0;
       }
     }
-    &>ul {
+    &>ul,
+    &>ol {
       margin-left: 1.5rem;
     }
 


### PR DESCRIPTION
Here is a fix for list indentation when using `mkdocs-material` as the theme.

In issue #145, I identified a problem where lists weren't indented properly when `mkdocs-material` was used under specific versions of `WeasyPrint`. So, I made some modifications to the `theme/material.scss` file that ensure the indentation of lists without needing to change the `WeasyPrint` version.
